### PR TITLE
SB-14 : Corrected a typo in Patient Refusal section.

### DIFF
--- a/src/components/subPages/PatientReport/PatientReport.component.jsx
+++ b/src/components/subPages/PatientReport/PatientReport.component.jsx
@@ -2141,7 +2141,7 @@ function PatientReport({
         <HeadingTwo text="Patient Refusal" marginBottom="1rem" />
         <HeadingThree text="Refusal Statement/Signature" />
         <ReportField
-          field="All the information and treatment options relating to my conditions/injuries have been explained. I fully understand the risks of refusing treatment or transport as advised by the ambulance clinician and I accept alll responsibility for my own care."
+          field="All the information and treatment options relating to my conditions/injuries have been explained. I fully understand the risks of refusing treatment or transport as advised by the ambulance clinician and I accept all responsibility for my own care."
           marginBottom="2rem"
         />
 


### PR DESCRIPTION
Sign and Sync now matches the mobile version of OneResponse - Management. *Please note that the signature images still need to be added!
[REPORT: Sign and Sync](https://app.gitkraken.com/glo/card/2532ab9cccf94165a1d9450997a95934)