### PR TITLE
SB-5: All tables adjusted but missing Drugs Refusal 'Drug'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>One Response</title>
+    <title>One Response - Management</title>
   </head>
 
   <body>

--- a/src/components/subPages/PatientReport/PatientReport.component.jsx
+++ b/src/components/subPages/PatientReport/PatientReport.component.jsx
@@ -713,7 +713,18 @@ function PatientReport({
 
   //#region drugsMedsRender = Drugs/Meds report #TODO - Needs testing
   const drugsMedsRender = drugsMedsData.map(
-    ({ id, Name, Pouch, Time, Dosage, Unit, Route, By, Own_Meds }) => (
+    ({
+      id,
+      Name,
+      Pouch,
+      Time,
+      Dosage,
+      Unit,
+      Route,
+      By,
+      Own_Meds,
+      Admin_PGD,
+    }) => (
       <PatientReportRender key={id} style={{ borderTop: "1px solid #e0e0e0" }}>
         <PatientReportTableGrid>
           <PatientReportColumn>
@@ -802,8 +813,20 @@ function PatientReport({
 
           <PatientReportColumn>
             <ReportField
-              field="Own Medications"
+              field="Own Medication"
               data={Own_Meds ? Own_Meds : "Not recorded"}
+              paddingBottom="0"
+              fontSize="0.71rem"
+              fieldFontWeight="700"
+              fieldMinHeight="45px"
+              fieldTextTransform="uppercase"
+            />
+          </PatientReportColumn>
+
+          <PatientReportColumn>
+            <ReportField
+              field="Admin PGD"
+              data={Admin_PGD ? Admin_PGD : "Not recorded"}
               paddingBottom="0"
               fontSize="0.71rem"
               fieldFontWeight="700"
@@ -817,7 +840,7 @@ function PatientReport({
   );
   //#endregion /drugsMedsRender = Drugs/Meds report
 
-  //#region drugsMedsRefusalRender = Drugs/Meds Refusal report #TODO - Needs testing
+  //#region drugsMedsRefusalRender = Drugs/Meds Refusal report #TODO - Missing 'Drug', needs testing
   const drugsMedsRefusalRender = drugsMedsData.map(
     ({ id, Drug_Refusal, Drug_By_Refusal }) => (
       <PatientReportRender key={id} style={{ borderTop: "1px solid #e0e0e0" }}>


### PR DESCRIPTION
IV Access, IV Not Canulated, Drugs / Meds and Drugs Refusal tables are now uniform, and match with the OneResponse - Management mobile version.

Note: Drugs Refusal data is missing Drugs Refusal 'Drug'.
[REPORT: IV Access and Medications](https://app.gitkraken.com/glo/card/dbda95a06d6a4a639f04a07954fcf442)