### PR TITLE
ERR#20

### DIFF
--- a/src/components/UI/Header/Header.component.jsx
+++ b/src/components/UI/Header/Header.component.jsx
@@ -55,6 +55,7 @@ const HeaderContainer = styled.div`
     "secondary-header";
   grid-template-rows: 7vh 5vh;
   min-height: 200px;
+  -webkit-tap-highlight-color: transparent;
 `;
 
 // Styled: HeaderPrimary

--- a/src/components/UI/PatientList/PatientList.component.jsx
+++ b/src/components/UI/PatientList/PatientList.component.jsx
@@ -86,7 +86,7 @@ const PatientListContainer = styled.div`
   transform: translateX(0%);
   transition: transform 150ms linear;
   width: 400px;
-
+  -webkit-tap-highlight-color: transparent;
   @media screen and (max-width: 768px) {
     width: 100vw;
   }

--- a/src/components/UI/ReportHeader/ReportHeader.component.jsx
+++ b/src/components/UI/ReportHeader/ReportHeader.component.jsx
@@ -89,6 +89,7 @@ const ReportHeaderContainer = styled.div`
   padding: 0 1rem;
   top: 0;
   width: 100%;
+  -webkit-tap-highlight-color: transparent;
 
   position: sticky;
   -webkit-position: sticky;


### PR DESCRIPTION
:As request I added '-webkit-tap-highlight-color: transparent' to get rid of the blue onclick highlight for the OneResponse logo, Patient List toggle, the whole Patient Item, and nav links in the Report Header. I have only managed to test on Google Chrome's mobile mode so it may require further testing.
