### PR TITLE
SB-27: Master ePR ID and Status added. Still need to work on Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@
 - `node-sass`
 - `styled-components`
 
+## Code Editors
+
+In terms of code editors, I would recommend the following in order:
+
+1. Visual Studio (VS) Code
+
+- Available [here](https://code.visualstudio.com/)
+
+2. Atom
+
+- Available [here](https://atom.io/)
+
 ## VS Code Extensions
 
 ### Optional

--- a/src/components/UI/PatientItem/PatientItem.component.jsx
+++ b/src/components/UI/PatientItem/PatientItem.component.jsx
@@ -7,14 +7,20 @@ import Icon from "../Icon/Icon.component";
 
 // UI: PatientItem
 function PatientItem({
+  id,
   PD_Firstname,
   PD_Surname,
   PD_Gender,
   PD_DOB,
+  MasterID,
   ePR_CallSign,
+  complete,
 }) {
+  // Truncates the MasterID (Master_ePR_ID) from the last "-"
+  const masterIdString = MasterID.split("-").pop();
+
   return (
-    <PatientItemContainer>
+    <PatientItemContainer key={id}>
       <PatientItemIcon className="PatientItemIcon-hover">
         <Icon icon="fas fa-user-alt" />
       </PatientItemIcon>
@@ -44,8 +50,16 @@ function PatientItem({
 
         <PatientItemStatus>
           <PatientItemStatusText>
+            {MasterID ? "..." + masterIdString : "Null"}
+          </PatientItemStatusText>
+
+          <PatientItemStatusText>
             {ePR_CallSign ? ePR_CallSign : <span>ePR CallSign</span>}
+          </PatientItemStatusText>
+
+          <PatientItemStatusText>
             <p>Status:</p>
+            {complete ? <span>Ready to Print</span> : <span>In Progress</span>}
           </PatientItemStatusText>
         </PatientItemStatus>
       </PatientItemWrapper>

--- a/src/components/UI/PatientList/PatientList.component.jsx
+++ b/src/components/UI/PatientList/PatientList.component.jsx
@@ -50,7 +50,7 @@ function PatientList({ isOpen, setSelectedPatient }) {
         key={Master_ePR_ID}
         onClick={() => setSelectedPatient(Master_ePR_ID)}
       >
-        <PatientItem {...otherPatientListProps} />
+        <PatientItem MasterID={Master_ePR_ID} {...otherPatientListProps} />
       </div>
     )
   );


### PR DESCRIPTION
Master ePR ID has been added and truncated to the last hyphen ("-"), with the remaining string being prefixed by "...".

Status has been related to the 'completed' field, and displays "Ready to Print" if completed === true, or "In Progress" if completed === false.

The time since admitted still needs to be worked on/added.
[UI: PatientItem](https://app.gitkraken.com/glo/card/c05ea3500d5c439faa05e0a69e33a4ae)