### PR TITLE
SB-28, SB-23: Signatures added and PatientItems filled

### DIFF
--- a/src/components/UI/PatientItem/PatientItem.component.jsx
+++ b/src/components/UI/PatientItem/PatientItem.component.jsx
@@ -12,13 +12,15 @@ function PatientItem({
   PD_Surname,
   PD_Gender,
   PD_DOB,
-  MasterID,
+  PVN_Transport,
+  PD_Incident_Number,
   ePR_Date,
   ePR_CallSign,
   complete,
 }) {
-  // Truncates the MasterID (Master_ePR_ID) from the last "-"
-  const masterIdString = MasterID.split("-").pop();
+  // Only shows the last n characters of the PD_Incident_Number string
+  const n = 10;
+  console.log(PD_Incident_Number.substring(PD_Incident_Number.length - n));
 
   // Calculates time difference between ePR_Date and current time
   // Calculates seconds since admission date (current Date - ePR_Date)
@@ -27,7 +29,6 @@ function PatientItem({
     // milliseconds to seconds, seconds to hours, hours to days
     (Date.now() - new Date(ePR_Date).getTime()) / 1000
   );
-  console.log("Seconds since admission: ", secondsSinceAdmission);
 
   // Converts secondsSinceAdmission into hours, minutes and seconds
   function secondsToHoursMinutesSeconds(sec) {
@@ -72,12 +73,19 @@ function PatientItem({
             <PatientItemOther>
               {PD_DOB ? PD_DOB : <span>Date of Birth</span>}
             </PatientItemOther>
+
+            <PatientItemOther>
+              {PVN_Transport ? PVN_Transport : <span>Reported Condition</span>}
+            </PatientItemOther>
           </PatientItemOtherContainer>
         </PatientItemSecondWrapper>
 
         <PatientItemStatus>
           <PatientItemStatusText>
-            {MasterID ? "..." + masterIdString : "Null"}
+            {PD_Incident_Number
+              ? "..." +
+                PD_Incident_Number.substring(PD_Incident_Number.length - n)
+              : "Null"}
           </PatientItemStatusText>
 
           <PatientItemStatusText>

--- a/src/components/UI/PatientList/PatientList.component.jsx
+++ b/src/components/UI/PatientList/PatientList.component.jsx
@@ -63,7 +63,7 @@ function PatientList({
           Master_ePR_ID === selectedPatient ? { background: "#2c2c2c" } : null
         }
       >
-        <PatientItem MasterID={Master_ePR_ID} {...otherPatientListProps} />
+        <PatientItem {...otherPatientListProps} />
       </div>
     )
   );

--- a/src/components/subPages/PatientReport/PatientReport.component.jsx
+++ b/src/components/subPages/PatientReport/PatientReport.component.jsx
@@ -2272,10 +2272,12 @@ function PatientReport({
       Final_Impression,
       staffNumberInput,
       professsional_Box,
+      signature,
       professionalRegNoInput,
       snrStaffNumberInput,
       snrProfessional_Box,
       snrProfessionalRegNoInput,
+      signatureSnrSig,
       signatureRefusalName,
     }) => (
       <PatientReportRender key={id}>
@@ -2308,11 +2310,13 @@ function PatientReport({
                   : "Not recorded"
               }
             />
-            <ReportField
-              field="Signature"
-              data="[Requires Signature render]"
-              marginBottom="2rem"
-            />
+            <ReportField field="Staff Signature" />
+            {signature && signature.length > 0 ? (
+              <img
+                src={"data:image/png;base64," + `${signature}`}
+                alt="Staff Signature"
+              />
+            ) : null}
           </PatientReportColumn>
 
           <PatientReportColumn>
@@ -2329,11 +2333,13 @@ function PatientReport({
                   : "Not recorded"
               }
             />
-            <ReportField
-              field="Signature"
-              data="[Requires Signature render]"
-              marginBottom="2rem"
-            />
+            <ReportField field="Senior Clinician's Signature" />
+            {signatureSnrSig && signatureSnrSig.length > 0 ? (
+              <img
+                src={"data:image/png;base64," + `${signatureSnrSig}`}
+                alt="Senior Clinician Signature"
+              />
+            ) : null}
           </PatientReportColumn>
         </PatientReportGrid>
 


### PR DESCRIPTION
**SB-28:**

1. `Master_ePR_ID` replaced with `PD_Incident_Number`.
2. `PD_Reported_Condition` added underneath Date of Birth.
3. Added: `Master_ePR_ID === selectedPatient ? { background: #2c2c2c } : null`

**SB-23:**

Added a signature render for the byte array string from the OneResponse Management API.

[REPORT: Sign and Sync signatures](https://app.gitkraken.com/glo/card/cc16f2874d6e4bf9aaab9043e2884c9b)
[UI: PatientItem](https://app.gitkraken.com/glo/card/22cdd3dbb967469d81de1b0d471800ab)