### PR TITLE
SB-25, SB-26: PatientList and PatientItems progressed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,7 +40,7 @@ function App() {
         </AppPatientList>
 
         <AppPatientReport>
-          <Report selectedPatient={selectedPatient} />
+          <Report selectedPatient={selectedPatient} isOpen={isOpen} />
         </AppPatientReport>
       </AppLayout>
     </AppContainer>

--- a/src/components/UI/PatientList/PatientList.component.jsx
+++ b/src/components/UI/PatientList/PatientList.component.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 // Import: UI
 import PatientItem from "../PatientItem/PatientItem.component";
+import Icon from "../Icon/Icon.component";
 
 // UI: PatientList
 function PatientList({
@@ -63,7 +64,15 @@ function PatientList({
           Master_ePR_ID === selectedPatient ? { background: "#2c2c2c" } : null
         }
       >
-        <PatientItem {...otherPatientListProps} />
+        <div
+          onClick={
+            window.innerWidth <= 768
+              ? () => setIsOpen((isOpen) => !isOpen)
+              : null
+          }
+        >
+          <PatientItem {...otherPatientListProps} />
+        </div>
       </div>
     )
   );
@@ -74,7 +83,26 @@ function PatientList({
         style={!isOpen ? { transform: "translateX(-100%" } : null}
       >
         <PatientListWrapper>
-          <PatientListHeader>Patients Created in last 72hrs</PatientListHeader>
+          <PatientListHeader>
+            <Icon icon="fas fa-hospital-user" />
+            Patients Created in last 72hrs
+          </PatientListHeader>
+
+          <PatientListButtonContainer>
+            <PatientListButton type="button">Incoming</PatientListButton>
+            <PatientListButton type="button">Arrived</PatientListButton>
+            <PatientListButton type="button">Processed</PatientListButton>
+          </PatientListButtonContainer>
+
+          <PatientListButtonContainer>
+            <PatientListButton type="button">PID</PatientListButton>
+            <PatientListButton type="button">Non-PID</PatientListButton>
+          </PatientListButtonContainer>
+
+          <PatientListCount>
+            <p>Patient Count: {Object.keys(patients).length}</p>
+          </PatientListCount>
+
           <PatientListLead>Please select from the list below:</PatientListLead>
         </PatientListWrapper>
         {patientListRender}
@@ -100,6 +128,7 @@ const PatientListContainer = styled.div`
   transition: transform 150ms linear;
   width: 400px;
   -webkit-tap-highlight-color: transparent;
+
   @media screen and (max-width: 768px) {
     width: 100vw;
   }
@@ -122,15 +151,20 @@ const PatientListLoadingMessage = styled.div`
 // Styled: PatientListWrapper
 const PatientListWrapper = styled.div`
   align-items: flex-start;
-  ${"" /* border-bottom: 1px solid rgba(255, 255, 255, 0.2); */}
+  background: #414141;
+  box-shadow: 0 5px 8px -9px rgba(0, 0, 0, 0.75);
   color: #ffffff;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
   justify-content: center;
   padding: 1rem;
+  position: sticky;
+  -webkit-position: sticky;
   text-align: left;
+  top: 0;
   width: 100%;
+  z-index: 9999;
 `;
 
 // Styled: PatientListHeader
@@ -142,10 +176,66 @@ const PatientListHeader = styled.span`
   @media screen and (max-width: 327px) {
     font-size: 1.2rem;
   }
+
+  & i {
+    font-size: 1.3rem;
+    margin-right: 6px;
+  }
 `;
 
 // Styled: PatientListLead
 const PatientListLead = styled.span`
   letter-spacing: 0.8px;
   opacity: 0.7;
+`;
+
+// Styled: PatientListButtonContainer
+const PatientListButtonContainer = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+  margin: 4px 0;
+  width: 100%;
+`;
+
+// Styled: PatientListButton
+const PatientListButton = styled.button`
+  background: #fff;
+  border: 2px solid transparent;
+  cursor: pointer;
+  display: inline;
+  font-size: 14px;
+  padding: 4px 0;
+  letter-spacing: 1px;
+  margin: 0 2px;
+  text-align: center;
+  text-decoration: none;
+  transition: all 150ms linear;
+  width: 100px;
+
+  &:hover {
+    background: #e0e0e0;
+    transition: all 150ms linear;
+  }
+
+  &:focus {
+    background: #414141;
+    border: 2px solid #fff;
+    color: #fff;
+    transition: all 150ms linear;
+  }
+`;
+
+// Styled: PatientListCount
+const PatientListCount = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding-top: 4px;
+
+  & p {
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+  }
 `;

--- a/src/components/UI/ReportHeader/ReportHeader.component.jsx
+++ b/src/components/UI/ReportHeader/ReportHeader.component.jsx
@@ -1,31 +1,33 @@
 // Import: Dependencies
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { NavLink } from "react-router-dom";
 
 // Import: Assets
-import { ReactComponent as NwasLogo } from "../../../assets/images/nwaslogo.svg";
+// import { ReactComponent as NwasLogo } from "../../../assets/images/nwaslogo.svg";
 
 // Import: UI
 import Icon from "../Icon/Icon.component";
 
 // UI: ReportHeader
-function ReportHeader() {
-  return (
-    <ReportHeaderContainer>
-      <ReportHeaderOptions>
-        {/* <NavLink
-          activeStyle={{
-            background: "#e0e0e0",
-            borderTop: "3px solid #569fd3",
-            transition: "background 150ms linear",
-          }}
-          to="/sbar"
-        >
-          <Icon icon="fas fa-laptop-medical" />
-          <li>SBAR</li>
-        </NavLink> */}
+function ReportHeader({ isOpen }) {
+  // State = windowWidth
+  const [windowWidth, setWindowWidth] = useState(0);
 
+  // useEffect = Checks and updates windowWidth
+  useEffect(() => {
+    const updateWindowDimensions = () => {
+      const newWidth = window.innerWidth;
+      setWindowWidth(newWidth);
+      console.log("Updating Height");
+    };
+
+    window.addEventListener("resize", updateWindowDimensions);
+  }, []);
+
+  return (
+    <ReportHeaderContainer isOpen={isOpen} windowWidth={windowWidth}>
+      <ReportHeaderOptions>
         <NavLink
           activeStyle={{
             background: "#e0e0e0",
@@ -87,9 +89,9 @@ function ReportHeader() {
         </NavLink>
       </ReportHeaderOptions>
 
-      <ReportHeaderLogo>
+      {/* <ReportHeaderLogo>
         <NwasLogo />
-      </ReportHeaderLogo>
+      </ReportHeaderLogo> */}
     </ReportHeaderContainer>
   );
 }
@@ -106,16 +108,23 @@ const ReportHeaderContainer = styled.div`
   height: auto;
   justify-content: space-between;
   padding: 0 1rem;
-  position: sticky;
-  -webkit-position: sticky;
+  position: ${({ isOpen, windowWidth }) => {
+    if (isOpen && windowWidth <= 768) {
+      return "static";
+    } else {
+      return "sticky";
+    }
+  }};
+  -webkit-position: ${({ isOpen, windowWidth }) => {
+    if (isOpen && windowWidth <= 768) {
+      return "static";
+    } else {
+      return "sticky";
+    }
+  }};
   top: 0;
   width: 100%;
   -webkit-tap-highlight-color: transparent;
-
-  @media screen and (max-width: 768px) {
-    position: static;
-    -webkit-position: static;
-  }
 
   & svg {
     height: 90px;
@@ -130,13 +139,13 @@ const ReportHeaderContainer = styled.div`
 `;
 
 // Styled: ReportHeaderLogo
-const ReportHeaderLogo = styled.div`
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  height: 80px;
-  width: 216px;
-`;
+// const ReportHeaderLogo = styled.div`
+//   align-items: center;
+//   display: flex;
+//   justify-content: center;
+//   height: 80px;
+//   width: 216px;
+// `;
 
 // Styled: ReportHeaderOptions
 const ReportHeaderOptions = styled.ul`

--- a/src/components/pages/Report/Report.component.jsx
+++ b/src/components/pages/Report/Report.component.jsx
@@ -16,7 +16,7 @@ import PatientReport from "../../subPages/PatientReport/PatientReport.component"
 // import Sbar from "../../subPages/Sbar/Sbar.component";
 
 // page: Report
-function Report({ selectedPatient }) {
+function Report({ selectedPatient, isOpen }) {
   // State = Report
   const [cadDetailsData, setCADDetailsData] = useState([]); // Incident Information
   const [patientDetailsData, setPatientDetailsData] = useState([]); // Patient Details
@@ -393,11 +393,11 @@ function Report({ selectedPatient }) {
   return (
     <ReportContainer>
       <ReportWrapper>
-        <PatientNameHeader
+        {/* <PatientNameHeader
           selectedPatient={selectedPatient}
           patientDetailsData={patientDetailsData}
-        />
-        <ReportHeader />
+        /> */}
+        <ReportHeader isOpen={isOpen} />
 
         <Switch>
           <Route exact path="/">

--- a/src/components/subPages/DiagnosisOfDeath/DiagnosisOfDeath.component.jsx
+++ b/src/components/subPages/DiagnosisOfDeath/DiagnosisOfDeath.component.jsx
@@ -4,9 +4,7 @@ import styled from "styled-components";
 
 // Import: UI
 import HeadingOne from "../../UI/Headings/HeadingOne/HeadingOne.component";
-import HeadingTwo from "../../UI/Headings/HeadingTwo/HeadingTwo.component";
 import HeadingThree from "../../UI/Headings/HeadingThree/HeadingThree.component";
-import HeadingFour from "../../UI/Headings/HeadingFour/HeadingFour.component";
 import ReportContainer from "../../UI/ReportContainer/ReportContainer.component";
 import ReportField from "../../UI/ReportField/ReportField.component";
 
@@ -338,15 +336,6 @@ const DiagnosisOfDeathGrid = styled.div`
   width: 100%;
 `;
 
-// Styled: DiagnosisOfDeathTableGrid
-const DiagnosisOfDeathTableGrid = styled.div`
-  display: grid;
-  grid-gap: 10px;
-  grid-template-columns: repeat(auto-fit, minmax(66px, 1fr));
-  height: 100%;
-  width: 100%;
-`;
-
 // Styled: DiagnosisOfDeathColumn
 const DiagnosisOfDeathColumn = styled.div`
   align-items: flex-start;
@@ -361,12 +350,4 @@ const DiagnosisOfDeathColumn = styled.div`
 const DiagnosisOfDeathHeadingContainer = styled.div`
   background: #e0e0e0;
   width: 100%;
-`;
-
-// Styled: DiagnosisOfDeathAddressContainer
-const DiagnosisOfDeathAddressContainer = styled.div`
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 `;

--- a/src/components/subPages/PatientReport/PatientReport.component.jsx
+++ b/src/components/subPages/PatientReport/PatientReport.component.jsx
@@ -2337,7 +2337,7 @@ function PatientReport({
             <ReportField field="Staff Signature" />
             {signature && signature.length > 0 ? (
               <img
-                src={"data:image/png;base64," + `${signature}`}
+                src={"data:image/png;base64," + signature}
                 alt="Staff Signature"
               />
             ) : null}
@@ -2360,7 +2360,7 @@ function PatientReport({
             <ReportField field="Senior Clinician's Signature" />
             {signatureSnrSig && signatureSnrSig.length > 0 ? (
               <img
-                src={"data:image/png;base64," + `${signatureSnrSig}`}
+                src={"data:image/png;base64," + signatureSnrSig}
                 alt="Senior Clinician Signature"
               />
             ) : null}

--- a/src/index.styles.scss
+++ b/src/index.styles.scss
@@ -2,7 +2,10 @@
 * {
   box-sizing: border-box;
   margin: 0;
+  outline: none !important;
   padding: 0;
+  -webkit-tap-highlight-color: rgba(255, 255, 255, 0) !important;
+  -webkit-focus-ring-color: rgba(255, 255, 255, 0) !important;
 }
 
 body {
@@ -11,8 +14,8 @@ body {
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   height: 100%;
-  overflow: hidden;
   margin: 0;
+  overflow: hidden;
   padding: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
**SB-25:**
Incoming, Arrived, Processed, PID, Non-PID and Patient Count have been added to the PatientList header. Each button still needs their functionality sorted.

**SB-26:**
On smaller screens, if the window.innerWidth <= 768(px), selecting a PatientItem will close the PatientList

**Other:**
The ReportHeader is now appropriately sticky across small/large screens.
[UI: PatientList](https://app.gitkraken.com/glo/card/1ee747dbc161470abd219a8760d8cf5f)